### PR TITLE
feat: add warning for "react/no-unknown-property"

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,5 +10,6 @@ module.exports = {
     "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
+    "react/no-unknown-property": "warn",
   },
 };


### PR DESCRIPTION
This adds a warning whenever an unknown property is being used on a JSX element. iE it will trigger when using `class` instead of `className`.