### PR TITLE
feat: add common environments to base config

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -1,8 +1,14 @@
 module.exports = {
   extends: ["plugin:prettier/recommended"],
   plugins: ["prettier", "import", "flowtype"],
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
+  },
   parserOptions: {
-    ecmaVersion: 2018,
     sourceType: "module",
   },
   rules: {


### PR DESCRIPTION
- adds `env` to the base eslint config
- enables the most common usecases

Note: we usually get this behavior in our projects by default, because the [react eslint-config](https://github.com/facebook/create-react-app/blob/main/packages/eslint-config-react-app/base.js#L24) includes it. However, we dont have this available in a non-React project.